### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/CGI/Application.pm
+++ b/lib/CGI/Application.pm
@@ -1,4 +1,4 @@
-class CGI::Application;
+unit class CGI::Application;
 
 # XXX: should be dump-html
 has %.run-modes   is rw = (start => 'dump');


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
