### PR TITLE
Remove extra trailing comma in test-depends

### DIFF
--- a/META.info
+++ b/META.info
@@ -4,7 +4,7 @@
     "description" : "incomplete Perl 6 port of the Perl 5 CGI::Application module",
     "build-depends" : [ ],
     "test-depends" : [
-        "Test",
+        "Test"
     ],
     "depends" : [ ],
     "provides" : {


### PR DESCRIPTION
The trailing comma in the test-depends array made the META.info invalid
json.  This change corrects this issue.
